### PR TITLE
feat: add pull_request_target event trigger to workflow

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -1,6 +1,6 @@
 name: Continuous Testing and Automated NPM Publication
 
-on: [push]
+on: [push, pull_request_target]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
It looks like there may be security implications for pull_request_target **https://securitylab.github.com/research/github-actions-preventing-pwn-requests/** but using the base image from a fork may not work.