### PR TITLE
fix commented out tests

### DIFF
--- a/tests/cucumber/features/3d-editor/combine-materials.feature
+++ b/tests/cucumber/features/3d-editor/combine-materials.feature
@@ -1,3 +1,4 @@
+@ignore
 Feature: User can combine multiple materials and create a new material
 
   Scenario:

--- a/tests/cucumber/features/3d-editor/combine-materials.feature
+++ b/tests/cucumber/features/3d-editor/combine-materials.feature
@@ -1,4 +1,3 @@
-@ignore
 Feature: User can combine multiple materials and create a new material
 
   Scenario:

--- a/tests/cucumber/support/widgets/items_list_widget.js
+++ b/tests/cucumber/support/widgets/items_list_widget.js
@@ -1,8 +1,7 @@
-import {Widget} from "../widget";
-import {SELECTORS} from "../selectors";
+import { Widget } from "../widget";
+import { SELECTORS } from "../selectors";
 
 export class ItemsListWidget extends Widget {
-
     constructor(selector) {
         super(selector);
         this._selectors = SELECTORS.itemsList;
@@ -13,9 +12,8 @@ export class ItemsListWidget extends Widget {
         exabrowser.waitForValue(selector);
         this.selectItemByIndex(itemIndex);
         exabrowser.setValueWithBackspaceClear(selector, name);
-        // TODO: remove the need for pause below
-        exabrowser.pause(1000);
-    };
+        exabrowser.keys("Tab");
+    }
 
     getSelectorPerItem(itemIndex, selectorName) {
         return this.getWrappedSelector(`${this._selectors.itemByIndex(itemIndex)} ${selectorName}`);
@@ -29,6 +27,5 @@ export class ItemsListWidget extends Widget {
         exabrowser.scrollAndClick(this.getSelectorPerItem(index, this._selectors.iconButtonDelete));
         // TODO: add check for disappear instead of pause below
         exabrowser.pause(1000);
-    };
-
+    }
 }


### PR DESCRIPTION
The tests in "User can combine multiple materials and create a new material" occasionally hung up because of the material name input that did not fire blur event after setting a value. My idea is to explicitly move focus from the input by Tab key.