### PR TITLE
Enable import of local XYZ files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1210,10 +1210,9 @@
             }
         },
         "@babel/register": {
-            "version": "7.17.7",
-            "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.17.7.tgz",
-            "integrity": "sha512-fg56SwvXRifootQEDQAu1mKdjh5uthPzdO0N6t358FktfL4XjAVXuH58ULoiW8mesxiOgNIrxiImqEwv0+hRRA==",
-            "dev": true,
+            "version": "7.21.0",
+            "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.21.0.tgz",
+            "integrity": "sha512-9nKsPmYDi5DidAqJaQooxIhsLJiNMkGr8ypQ8Uic7cIox7UCDsM7HuUGxdGT7mSDTYbqzIdsOWzfBton/YJrMw==",
             "requires": {
                 "clone-deep": "^4.0.1",
                 "find-cache-dir": "^2.0.0",
@@ -1299,9 +1298,9 @@
             }
         },
         "@codemirror/autocomplete": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.4.0.tgz",
-            "integrity": "sha512-HLF2PnZAm1s4kGs30EiqKMgD7XsYaQ0XJnMR0rofEWQ5t5D60SfqpDIkIh1ze5tiEbyUWm8+VJ6W1/erVvBMIA==",
+            "version": "6.4.2",
+            "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.4.2.tgz",
+            "integrity": "sha512-8WE2xp+D0MpWEv5lZ6zPW1/tf4AGb358T5GWYiKEuCP8MvFfT3tH2mIF9Y2yr2e3KbHuSvsVhosiEyqCpiJhZQ==",
             "requires": {
                 "@codemirror/language": "^6.0.0",
                 "@codemirror/state": "^6.0.0",
@@ -1310,9 +1309,9 @@
             }
         },
         "@codemirror/commands": {
-            "version": "6.2.0",
-            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.0.tgz",
-            "integrity": "sha512-+00smmZBradoGFEkRjliN7BjqPh/Hx0KCHWOEibUmflUqZz2RwBTU0MrVovEEHozhx3AUSGcO/rl3/5f9e9Biw==",
+            "version": "6.2.1",
+            "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.2.1.tgz",
+            "integrity": "sha512-FFiNKGuHA5O8uC6IJE5apI5rT9gyjlw4whqy4vlcX0wE/myxL6P1s0upwDhY4HtMWLOwzwsp0ap3bjdQhvfDOA==",
             "requires": {
                 "@codemirror/language": "^6.0.0",
                 "@codemirror/state": "^6.2.0",
@@ -1321,12 +1320,12 @@
             }
         },
         "@codemirror/lang-javascript": {
-            "version": "6.1.3",
-            "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.1.3.tgz",
-            "integrity": "sha512-u3JgK9AwfNpyGwRhtzIVxVfH9yOK5ZNswmaN6W+XFuUXzW9o8CGgnSBEcaUgZ0hdLvHQHyM+3+22HKgbItki/w==",
+            "version": "6.1.4",
+            "resolved": "https://registry.npmjs.org/@codemirror/lang-javascript/-/lang-javascript-6.1.4.tgz",
+            "integrity": "sha512-OxLf7OfOZBTMRMi6BO/F72MNGmgOd9B0vetOLvHsDACFXayBzW8fm8aWnDM0yuy68wTK03MBf4HbjSBNRG5q7A==",
             "requires": {
                 "@codemirror/autocomplete": "^6.0.0",
-                "@codemirror/language": "^6.0.0",
+                "@codemirror/language": "^6.6.0",
                 "@codemirror/lint": "^6.0.0",
                 "@codemirror/state": "^6.0.0",
                 "@codemirror/view": "^6.0.0",
@@ -1335,9 +1334,9 @@
             }
         },
         "@codemirror/language": {
-            "version": "6.4.0",
-            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.4.0.tgz",
-            "integrity": "sha512-Wzb7GnNj8vnEtbPWiOy9H0m1fBtE28kepQNGLXekU2EEZv43BF865VKITUn+NoV8OpW6gRtvm29YEhqm46927Q==",
+            "version": "6.6.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.6.0.tgz",
+            "integrity": "sha512-cwUd6lzt3MfNYOobdjf14ZkLbJcnv4WtndYaoBkbor/vF+rCNguMPK0IRtvZJG4dsWiaWPcK8x1VijhvSxnstg==",
             "requires": {
                 "@codemirror/state": "^6.0.0",
                 "@codemirror/view": "^6.0.0",
@@ -1348,9 +1347,9 @@
             }
         },
         "@codemirror/lint": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.1.0.tgz",
-            "integrity": "sha512-mdvDQrjRmYPvQ3WrzF6Ewaao+NWERYtpthJvoQ3tK3t/44Ynhk8ZGjTSL9jMEv8CgSMogmt75X8ceOZRDSXHtQ==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.2.0.tgz",
+            "integrity": "sha512-KVCECmR2fFeYBr1ZXDVue7x3q5PMI0PzcIbA+zKufnkniMBo1325t0h1jM85AKp8l3tj67LRxVpZfgDxEXlQkg==",
             "requires": {
                 "@codemirror/state": "^6.0.0",
                 "@codemirror/view": "^6.0.0",
@@ -1373,9 +1372,9 @@
             "integrity": "sha512-69QXtcrsc3RYtOtd+GsvczJ319udtBf1PTrr2KbLWM/e2CXUPnh0Nz9AUo8WfhSQ7GeL8dPVNUmhQVgpmuaNGA=="
         },
         "@codemirror/theme-one-dark": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.0.tgz",
-            "integrity": "sha512-AiTHtFRu8+vWT9wWUWDM+cog6ZwgivJogB1Tm/g40NIpLwph7AnmxrSzWfvJN5fBVufsuwBxecQCNmdcR5D7Aw==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.1.tgz",
+            "integrity": "sha512-+CfzmScfJuD6uDF5bHJkAjWTQ2QAAHxODCPxUEgcImDYcJLT+4l5vLnBHmDVv46kCC5uUJGMrBJct2Z6JbvqyQ==",
             "requires": {
                 "@codemirror/language": "^6.0.0",
                 "@codemirror/state": "^6.0.0",
@@ -1384,9 +1383,9 @@
             }
         },
         "@codemirror/view": {
-            "version": "6.7.3",
-            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.7.3.tgz",
-            "integrity": "sha512-Lt+4POnhXrZFfHOdPzXEHxrzwdy7cjqYlMkOWvoFGi6/bAsjzlFfr0NY3B15B/PGx+cDFgM1hlc12wvYeZbGLw==",
+            "version": "6.9.1",
+            "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.9.1.tgz",
+            "integrity": "sha512-bzfSjJn9dAADVpabLKWKNmMG4ibyTV2e3eOGowjElNPTdTkSbi6ixPYHm2u0ADcETfKsi2/R84Rkmi91dH9yEg==",
             "requires": {
                 "@codemirror/state": "^6.1.4",
                 "style-mod": "^4.0.0",
@@ -1635,16 +1634,126 @@
                 }
             }
         },
+        "@exabyte-io/code.js": {
+            "version": "2023.2.4-0",
+            "resolved": "https://registry.npmjs.org/@exabyte-io/code.js/-/code.js-2023.2.4-0.tgz",
+            "integrity": "sha512-9Te96vWig8N7HYsNT2ZHx+JXi1+VUB/R4vsOmeNkNQh6NO5iaJXzL7hb2UI57qvUkj5ZPnsuViM0sAjho0W3Kg==",
+            "requires": {
+                "@babel/cli": "7.16.0",
+                "@babel/core": "7.16.0",
+                "@babel/eslint-parser": "7.16.3",
+                "@babel/plugin-proposal-class-properties": "7.16.0",
+                "@babel/preset-env": "7.16.4",
+                "@babel/preset-react": "7.16.7",
+                "@babel/register": "^7.16.0",
+                "@babel/runtime-corejs3": "7.16.8",
+                "@exabyte-io/esse.js": "2022.10.21-1",
+                "crypto-js": "^4.1.1",
+                "json-schema-merge-allof": "^0.8.1",
+                "lodash": "^4.17.21",
+                "mathjs": "^3.9.0",
+                "mixwith": "^0.1.1",
+                "underscore": "^1.13.3",
+                "underscore.string": "^3.3.4",
+                "uuid": "8.3.2"
+            },
+            "dependencies": {
+                "@babel/eslint-parser": {
+                    "version": "7.16.3",
+                    "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.3.tgz",
+                    "integrity": "sha512-iB4ElZT0jAt7PKVaeVulOECdGe6UnmA/O0P9jlF5g5GBOwDVbna8AXhHRu4s27xQf6OkveyA8iTDv1jHdDejgQ==",
+                    "requires": {
+                        "eslint-scope": "^5.1.1",
+                        "eslint-visitor-keys": "^2.1.0",
+                        "semver": "^6.3.0"
+                    }
+                },
+                "@babel/runtime-corejs3": {
+                    "version": "7.16.8",
+                    "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.16.8.tgz",
+                    "integrity": "sha512-3fKhuICS1lMz0plI5ktOE/yEtBRMVxplzRkdn6mJQ197XiY0JnrzYV0+Mxozq3JZ8SBV9Ecurmw1XsGbwOf+Sg==",
+                    "requires": {
+                        "core-js-pure": "^3.20.2",
+                        "regenerator-runtime": "^0.13.4"
+                    }
+                },
+                "crypto-js": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.1.1.tgz",
+                    "integrity": "sha512-o2JlM7ydqd3Qk9CA0L4NL6mTzU2sdx96a+oOfPu8Mkl/PK51vSyoi8/rQ8NknZtk44vq15lmhAj9CIAGwgeWKw=="
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                }
+            }
+        },
         "@exabyte-io/eslint-config": {
             "version": "2022.11.17-0",
             "resolved": "https://registry.npmjs.org/@exabyte-io/eslint-config/-/eslint-config-2022.11.17-0.tgz",
             "integrity": "sha512-BYTDSqvjj6ZiWb8l46T5BKrVfkelct+vK2mh7joHu5UWtJMUzLkb0KQMV1+6SUy4xHFnws33XS7/+JSW1yeZOQ==",
             "dev": true
         },
+        "@exabyte-io/esse.js": {
+            "version": "2022.10.21-1",
+            "resolved": "https://registry.npmjs.org/@exabyte-io/esse.js/-/esse.js-2022.10.21-1.tgz",
+            "integrity": "sha512-7P7KvSHMcJCxpCiu8e8LSUHHZyt1z7p2Kx9KZgizJT3+qRHv75r4ZRlXKjaPFMddFtNHbNRDJRvJL86Tczyx2Q==",
+            "requires": {
+                "@babel/cli": "7.16.0",
+                "@babel/core": "7.16.0",
+                "@babel/eslint-parser": "7.16.3",
+                "@babel/preset-env": "7.16.4",
+                "@babel/register": "7.16.0",
+                "ajv": "^4.1.7",
+                "file": "^0.2.2",
+                "json-schema-deref-sync": "0.14.0",
+                "lodash": "4.17.21",
+                "yamljs": "^0.3.0"
+            },
+            "dependencies": {
+                "@babel/eslint-parser": {
+                    "version": "7.16.3",
+                    "resolved": "https://registry.npmjs.org/@babel/eslint-parser/-/eslint-parser-7.16.3.tgz",
+                    "integrity": "sha512-iB4ElZT0jAt7PKVaeVulOECdGe6UnmA/O0P9jlF5g5GBOwDVbna8AXhHRu4s27xQf6OkveyA8iTDv1jHdDejgQ==",
+                    "requires": {
+                        "eslint-scope": "^5.1.1",
+                        "eslint-visitor-keys": "^2.1.0",
+                        "semver": "^6.3.0"
+                    }
+                },
+                "@babel/register": {
+                    "version": "7.16.0",
+                    "resolved": "https://registry.npmjs.org/@babel/register/-/register-7.16.0.tgz",
+                    "integrity": "sha512-lzl4yfs0zVXnooeLE0AAfYaT7F3SPA8yB2Bj4W1BiZwLbMS3MZH35ZvCWSRHvneUugwuM+Wsnrj7h0F7UmU3NQ==",
+                    "requires": {
+                        "clone-deep": "^4.0.1",
+                        "find-cache-dir": "^2.0.0",
+                        "make-dir": "^2.1.0",
+                        "pirates": "^4.0.0",
+                        "source-map-support": "^0.5.16"
+                    }
+                },
+                "ajv": {
+                    "version": "4.11.8",
+                    "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.8.tgz",
+                    "integrity": "sha512-I/bSHSNEcFFqXLf91nchoNB9D1Kie3QKcWdchYUaoIg1+1bdWDkdfdlvdIOJbi9U8xR0y+MWc5D+won9v95WlQ==",
+                    "requires": {
+                        "co": "^4.6.0",
+                        "json-stable-stringify": "^1.0.1"
+                    }
+                },
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                }
+            }
+        },
         "@exabyte-io/made.js": {
-            "version": "2022.5.5-3",
-            "resolved": "https://registry.npmjs.org/@exabyte-io/made.js/-/made.js-2022.5.5-3.tgz",
-            "integrity": "sha512-esKIIkJYUswhWXf7/TDMvdo2O28+50vX2HoHNmdpM6ClP6EUNOVKu2DYLw+ch5wuOJY2ifusqtlB4qEErZp64g==",
+            "version": "2023.2.28-0",
+            "resolved": "https://registry.npmjs.org/@exabyte-io/made.js/-/made.js-2023.2.28-0.tgz",
+            "integrity": "sha512-6RdEo2Zc3kvek0sl5ECMCrswlopA+CAC8Foe5zMQZnuVfGoEcxi65/92WQUebxIl7u/flEEbWA3Z4dWIcvalqQ==",
             "dev": true,
             "requires": {
                 "@babel/cli": "^7.16.0",
@@ -5325,6 +5434,11 @@
             "resolved": "https://registry.npmjs.org/charcodes/-/charcodes-0.2.0.tgz",
             "integrity": "sha512-Y4kiDb+AM4Ecy58YkuZrrSRJBDQdQ2L+NyS1vHHFtNtUjgutcZfx3yp1dAONI/oPaPmyGfCLx5CxL+zauIMyKQ=="
         },
+        "charenc": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+            "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
+        },
         "check-types": {
             "version": "11.1.2",
             "resolved": "https://registry.npmjs.org/check-types/-/check-types-11.1.2.tgz",
@@ -5505,6 +5619,11 @@
                 "wrap-ansi": "^6.2.0"
             }
         },
+        "clone": {
+            "version": "2.1.2",
+            "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
+            "integrity": "sha512-3Pe/CF1Nn94hyhIYpjtiLhdCoEoz0DqQ+988E9gmeEdQZlojxnOb74wctFyuwWQHzqyf9X7C7MG8juUpqBJT8w=="
+        },
         "clone-deep": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/clone-deep/-/clone-deep-4.0.1.tgz",
@@ -5673,6 +5792,27 @@
                     "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
                     "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
                 }
+            }
+        },
+        "compute-gcd": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/compute-gcd/-/compute-gcd-1.2.1.tgz",
+            "integrity": "sha512-TwMbxBNz0l71+8Sc4czv13h4kEqnchV9igQZBi6QUaz09dnz13juGnnaWWJTRsP3brxOoxeB4SA2WELLw1hCtg==",
+            "requires": {
+                "validate.io-array": "^1.0.3",
+                "validate.io-function": "^1.0.2",
+                "validate.io-integer-array": "^1.0.0"
+            }
+        },
+        "compute-lcm": {
+            "version": "1.1.2",
+            "resolved": "https://registry.npmjs.org/compute-lcm/-/compute-lcm-1.1.2.tgz",
+            "integrity": "sha512-OFNPdQAXnQhDSKioX8/XYT6sdUlXwpeMjfd6ApxMJfyZ4GxmLR1xvMERctlYhlHwIiz6CSpBc2+qYKjHGZw4TQ==",
+            "requires": {
+                "compute-gcd": "^1.2.1",
+                "validate.io-array": "^1.0.3",
+                "validate.io-function": "^1.0.2",
+                "validate.io-integer-array": "^1.0.0"
             }
         },
         "concat-map": {
@@ -5943,6 +6083,11 @@
                 "shebang-command": "^1.2.0",
                 "which": "^1.2.9"
             }
+        },
+        "crypt": {
+            "version": "0.0.2",
+            "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+            "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
         },
         "crypto-browserify": {
             "version": "3.12.0",
@@ -6317,6 +6462,11 @@
                 "es5-ext": "^0.10.50",
                 "type": "^1.0.1"
             }
+        },
+        "dag-map": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/dag-map/-/dag-map-1.0.2.tgz",
+            "integrity": "sha512-+LSAiGFwQ9dRnRdOeaj7g47ZFJcOUPukAP8J3A3fuZ1g9Y44BG+P1sgApjLXTQPOzC4+7S9Wr8kXsfpINM4jpw=="
         },
         "damerau-levenshtein": {
             "version": "1.0.8",
@@ -8252,6 +8402,11 @@
             "resolved": "https://registry.npmjs.org/figgy-pudding/-/figgy-pudding-3.5.2.tgz",
             "integrity": "sha512-0btnI/H8f2pavGMN8w40mlSKOfTK2SVJmBfBeVIj3kNw0swwgzyRq0d5TJVOwodFmtvpPeWPN/MCcfuWF0Ezbw=="
         },
+        "file": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/file/-/file-0.2.2.tgz",
+            "integrity": "sha512-gwabMtChzdnpDJdPEpz8Vr/PX0pU85KailuPV71Zw/un5yJVKvzukhB3qf6O3lnTwIe5CxlMYLh3jOK3w5xrLA=="
+        },
         "file-entry-cache": {
             "version": "6.0.1",
             "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-6.0.1.tgz",
@@ -9917,6 +10072,29 @@
             "resolved": "https://registry.npmjs.org/is-in-browser/-/is-in-browser-1.1.3.tgz",
             "integrity": "sha512-FeXIBgG/CPGd/WUxuEyvgGTEfwiG9Z4EKGxjNMRqviiIIfsmgrpnHLffEDdwUHqNva1VEW91o3xBT/m8Elgl9g=="
         },
+        "is-invalid-path": {
+            "version": "0.1.0",
+            "resolved": "https://registry.npmjs.org/is-invalid-path/-/is-invalid-path-0.1.0.tgz",
+            "integrity": "sha512-aZMG0T3F34mTg4eTdszcGXx54oiZ4NtHSft3hWNJMGJXUUqdIj3cOZuHcU0nCWWcY3jd7yRe/3AEm3vSNTpBGQ==",
+            "requires": {
+                "is-glob": "^2.0.0"
+            },
+            "dependencies": {
+                "is-extglob": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
+                    "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww=="
+                },
+                "is-glob": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
+                    "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
+                    "requires": {
+                        "is-extglob": "^1.0.0"
+                    }
+                }
+            }
+        },
         "is-module": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -10058,6 +10236,14 @@
             "version": "0.2.1",
             "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
             "integrity": "sha512-rMYPYvCzsXywIsldgLaSoPlw5PfoB/ssr7hY4pLfcodrA5M/eArza1a9VmTiNIBNMjOGr1Ow9mTyU2o69U6U9Q=="
+        },
+        "is-valid-path": {
+            "version": "0.1.1",
+            "resolved": "https://registry.npmjs.org/is-valid-path/-/is-valid-path-0.1.1.tgz",
+            "integrity": "sha512-+kwPrVDu9Ms03L90Qaml+79+6DZHqHyRoANI6IsZJ/g8frhnfchDOBCa0RbQ6/kdHt5CS5OeIEyrYznNuVN+8A==",
+            "requires": {
+                "is-invalid-path": "^0.1.0"
+            }
         },
         "is-weakref": {
             "version": "1.0.2",
@@ -11651,10 +11837,51 @@
             "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
             "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
         },
+        "json-schema-compare": {
+            "version": "0.2.2",
+            "resolved": "https://registry.npmjs.org/json-schema-compare/-/json-schema-compare-0.2.2.tgz",
+            "integrity": "sha512-c4WYmDKyJXhs7WWvAWm3uIYnfyWFoIp+JEoX34rctVvEkMYCPGhXtvmFFXiffBbxfZsvQ0RNnV5H7GvDF5HCqQ==",
+            "requires": {
+                "lodash": "^4.17.4"
+            }
+        },
+        "json-schema-deref-sync": {
+            "version": "0.14.0",
+            "resolved": "https://registry.npmjs.org/json-schema-deref-sync/-/json-schema-deref-sync-0.14.0.tgz",
+            "integrity": "sha512-yGR1xmhdiD6R0MSrwWcFxQzAj5b3i5Gb/mt5tvQKgFMMeNe0KZYNEN/jWr7G+xn39Azqgcvk4ZKMs8dQl8e4wA==",
+            "requires": {
+                "clone": "^2.1.2",
+                "dag-map": "~1.0.0",
+                "is-valid-path": "^0.1.1",
+                "lodash": "^4.17.13",
+                "md5": "~2.2.0",
+                "memory-cache": "~0.2.0",
+                "traverse": "~0.6.6",
+                "valid-url": "~1.0.9"
+            }
+        },
+        "json-schema-merge-allof": {
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/json-schema-merge-allof/-/json-schema-merge-allof-0.8.1.tgz",
+            "integrity": "sha512-CTUKmIlPJbsWfzRRnOXz+0MjIqvnleIXwFTzz+t9T86HnYX/Rozria6ZVGLktAU9e+NygNljveP+yxqtQp/Q4w==",
+            "requires": {
+                "compute-lcm": "^1.1.2",
+                "json-schema-compare": "^0.2.2",
+                "lodash": "^4.17.20"
+            }
+        },
         "json-schema-traverse": {
             "version": "0.4.1",
             "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
             "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+        },
+        "json-stable-stringify": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.2.tgz",
+            "integrity": "sha512-eunSSaEnxV12z+Z73y/j5N37/In40GK4GmsSy+tEHJMxknvqnA7/djeYtAgW0GsWHUfg+847WJjKaEylk2y09g==",
+            "requires": {
+                "jsonify": "^0.0.1"
+            }
         },
         "json-stable-stringify-without-jsonify": {
             "version": "1.0.1",
@@ -11679,6 +11906,11 @@
                 "graceful-fs": "^4.1.6",
                 "universalify": "^2.0.0"
             }
+        },
+        "jsonify": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.1.tgz",
+            "integrity": "sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg=="
         },
         "jsprim": {
             "version": "1.4.2",
@@ -12302,6 +12534,16 @@
                 "typed-function": "0.10.7"
             }
         },
+        "md5": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+            "integrity": "sha512-PlGG4z5mBANDGCKsYQe0CaUYHdZYZt8ZPZLmEt+Urf0W4GlpTX4HescwHU+dc9+Z/G/vZKYZYFrwgm9VxK6QOQ==",
+            "requires": {
+                "charenc": "~0.0.1",
+                "crypt": "~0.0.1",
+                "is-buffer": "~1.1.1"
+            }
+        },
         "md5.js": {
             "version": "1.3.5",
             "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -12321,6 +12563,11 @@
             "version": "0.3.0",
             "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
             "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ=="
+        },
+        "memory-cache": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/memory-cache/-/memory-cache-0.2.0.tgz",
+            "integrity": "sha512-OcjA+jzjOYzKmKS6IQVALHLVz+rNTMPoJvCztFaZxwG14wtAW7VRZjwTQu06vKCYOxh4jVnik7ya0SXTB0W+xA=="
         },
         "memory-fs": {
             "version": "0.4.1",
@@ -18103,6 +18350,11 @@
                 "punycode": "^2.1.1"
             }
         },
+        "traverse": {
+            "version": "0.6.7",
+            "resolved": "https://registry.npmjs.org/traverse/-/traverse-0.6.7.tgz",
+            "integrity": "sha512-/y956gpUo9ZNCb99YjxG7OaslxZWHfCHAUUfshwqOXmxUIvqLjVO581BT+gM59+QV9tFe6/CGG53tsA1Y7RSdg=="
+        },
         "trim-newlines": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -18543,6 +18795,11 @@
                 }
             }
         },
+        "valid-url": {
+            "version": "1.0.9",
+            "resolved": "https://registry.npmjs.org/valid-url/-/valid-url-1.0.9.tgz",
+            "integrity": "sha512-QQDsV8OnSf5Uc30CKSwG9lnhMPe6exHtTXLRYX8uMwKENy640pU+2BgBL0LRbDh/eYRahNCS7aewCx0wf3NYVA=="
+        },
         "validate-npm-package-license": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz",
@@ -18551,6 +18808,38 @@
                 "spdx-correct": "^3.0.0",
                 "spdx-expression-parse": "^3.0.0"
             }
+        },
+        "validate.io-array": {
+            "version": "1.0.6",
+            "resolved": "https://registry.npmjs.org/validate.io-array/-/validate.io-array-1.0.6.tgz",
+            "integrity": "sha512-DeOy7CnPEziggrOO5CZhVKJw6S3Yi7e9e65R1Nl/RTN1vTQKnzjfvks0/8kQ40FP/dsjRAOd4hxmJ7uLa6vxkg=="
+        },
+        "validate.io-function": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/validate.io-function/-/validate.io-function-1.0.2.tgz",
+            "integrity": "sha512-LlFybRJEriSuBnUhQyG5bwglhh50EpTL2ul23MPIuR1odjO7XaMLFV8vHGwp7AZciFxtYOeiSCT5st+XSPONiQ=="
+        },
+        "validate.io-integer": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/validate.io-integer/-/validate.io-integer-1.0.5.tgz",
+            "integrity": "sha512-22izsYSLojN/P6bppBqhgUDjCkr5RY2jd+N2a3DCAUey8ydvrZ/OkGvFPR7qfOpwR2LC5p4Ngzxz36g5Vgr/hQ==",
+            "requires": {
+                "validate.io-number": "^1.0.3"
+            }
+        },
+        "validate.io-integer-array": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/validate.io-integer-array/-/validate.io-integer-array-1.0.0.tgz",
+            "integrity": "sha512-mTrMk/1ytQHtCY0oNO3dztafHYyGU88KL+jRxWuzfOmQb+4qqnWmI+gykvGp8usKZOM0H7keJHEbRaFiYA0VrA==",
+            "requires": {
+                "validate.io-array": "^1.0.3",
+                "validate.io-integer": "^1.0.4"
+            }
+        },
+        "validate.io-number": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/validate.io-number/-/validate.io-number-1.0.3.tgz",
+            "integrity": "sha512-kRAyotcbNaSYoDnXvb4MHg/0a1egJdLwS6oJ38TJY7aw9n93Fl/3blIXdyYvPOp55CNxywooG/3BcrwNrBpcSg=="
         },
         "vary": {
             "version": "1.1.2",
@@ -20012,6 +20301,15 @@
             "version": "1.10.2",
             "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
             "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg=="
+        },
+        "yamljs": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+            "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+            "requires": {
+                "argparse": "^1.0.7",
+                "glob": "^7.0.5"
+            }
         },
         "yargs": {
             "version": "15.4.1",

--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
         "eslint-plugin-jsx-a11y": "6.5.1",
         "eslint-plugin-prettier": "^4.2.1",
         "eslint-plugin-react": "7.27.1",
-        "eslint-plugin-simple-import-sort": "7.0.0",
+        "eslint-plugin-simple-import-sort": "^7.0.0",
         "husky": "7.0.4",
         "lint-staged": "12.1.2",
         "prettier": "2.5.1",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
         "@babel/runtime-corejs2": "7.16.7",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
+        "@exabyte-io/code.js": "2023.2.4-0",
         "@exabyte-io/wave.js": "2023.2.7-0",
         "@mui/icons-material": "^5.11.0",
         "@mui/material": "^5.11.7",
@@ -70,7 +71,7 @@
     },
     "devDependencies": {
         "@exabyte-io/eslint-config": "^2022.11.17-0",
-        "@exabyte-io/made.js": "2022.5.5-3",
+        "@exabyte-io/made.js": "2023.2.28-0",
         "babel-eslint": "^10.1.0",
         "babel-preset-react-app": "^9.1.2",
         "cross-env": "^7.0.3",

--- a/src/MaterialsDesigner.jsx
+++ b/src/MaterialsDesigner.jsx
@@ -7,6 +7,7 @@ import React from "react";
 import { ThreeDEditorFullscreen } from "./components/3d_editor/ThreeDEditorFullscreen";
 import EditorSelectionInfo from "./components/3d_editor_selection_info/EditorSelectionInfo";
 import HeaderMenuToolbar from "./components/header_menu/HeaderMenuToolbar";
+import DefaultImportModalDialog from "./components/include/DefaultImportModalDialog";
 import { FullscreenComponentMixin } from "./components/include/FullscreenComponentMixin";
 import { DarkMaterialUITheme } from "./components/include/material-ui/theme";
 import ItemsList from "./components/items_list/ItemsList";
@@ -70,7 +71,7 @@ class MaterialsDesigner extends mix(React.Component).with(FullscreenComponentMix
                                     onExport={this.props.onExport}
                                     onSave={this.props.onSave}
                                     onExit={this.props.onExit}
-                                    ImportModal={this.props.ImportModal}
+                                    ImportModal={this.props.ImportModal || DefaultImportModalDialog}
                                     SaveActionDialog={this.props.SaveActionDialog}
                                     onGenerateSupercell={this.props.onGenerateSupercell}
                                     onGenerateSurface={this.props.onGenerateSurface}

--- a/src/components/include/DefaultImportModalDialog.jsx
+++ b/src/components/include/DefaultImportModalDialog.jsx
@@ -99,17 +99,7 @@ class DefaultImportModalDialog extends ModalDialog {
     renderHeader() {
         return (
             <ModalHeader className="bgm-dark" closeButton>
-                <h4 className="modal-title">
-                    {this.props.title}
-                    <a
-                        className="m-l-10 combinatorial-info"
-                        href="https://docs.exabyte.io/materials-designer/header-menu/advanced/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                    >
-                        <i className="zmdi zmdi-info" />
-                    </a>
-                </h4>
+                <h4 className="modal-title">{this.props.title}</h4>
             </ModalHeader>
         );
     }

--- a/src/components/include/DefaultImportModalDialog.jsx
+++ b/src/components/include/DefaultImportModalDialog.jsx
@@ -75,7 +75,7 @@ class DefaultImportModalDialog extends ModalDialog {
             ...{
                 basis: basis.toJSON(),
                 lattice: lattice.toJSON(),
-                name: `${material.name} - ${basis.formula}`,
+                name: `${this.reader.currentFilename} - ${basis.formula}`,
             },
         };
         const newMaterial = new Material(newMaterialConfig);

--- a/src/components/include/DefaultImportModalDialog.jsx
+++ b/src/components/include/DefaultImportModalDialog.jsx
@@ -1,4 +1,5 @@
 import { Made } from "@exabyte-io/made.js";
+import { defaultMaterialConfig } from "@exabyte-io/made.js/lib/material";
 import { PropTypes } from "prop-types";
 import React from "react";
 import { ModalBody, ModalHeader } from "react-bootstrap";
@@ -8,38 +9,6 @@ import _ from "underscore";
 import { Material } from "../../material";
 import BasisText from "../source_editor/BasisText";
 import { ModalDialog } from "./ModalDialog";
-
-export const defaultXYZMaterialConfig = {
-    name: "Custom XYZ",
-    basis: {
-        elements: [
-            {
-                id: 1,
-                value: "H",
-            },
-        ],
-        coordinates: [
-            {
-                id: 1,
-                value: [0.0, 0.0, 0.0],
-            },
-        ],
-        units: Made.ATOMIC_COORD_UNITS.cartesian,
-    },
-    lattice: {
-        type: Made.LATTICE_TYPE_CONFIGS[1].code, // FCC, to be exported by made.js
-        a: 500.0, // NB will be rewritten with mockLatticeConstant
-        b: 500.0,
-        c: 500.0,
-        alpha: 90,
-        beta: 90,
-        gamma: 90,
-        units: {
-            length: Made.units.angstrom,
-            angle: Made.units.degree,
-        },
-    },
-};
 
 const mockLatticeConstantMultiplicator = 2.0;
 
@@ -84,7 +53,7 @@ class DefaultImportModalDialog extends ModalDialog {
         const diffZ = _.max(z) - _.min(z);
         const mockLatticeConstant = _.max([diffX, diffY, diffZ]) * mockLatticeConstantMultiplicator;
 
-        const material = new Made.Material(defaultXYZMaterialConfig);
+        const material = new Made.Material(defaultMaterialConfig);
 
         const latticeConfig = {
             ...material.lattice,

--- a/src/components/include/DefaultImportModalDialog.jsx
+++ b/src/components/include/DefaultImportModalDialog.jsx
@@ -147,6 +147,8 @@ class DefaultImportModalDialog extends ModalDialog {
         );
     }
 
+    // TODO: resolve the linter issue:
+    //   Line 150:17:  Expected 'this' to be used by class method 'renderFooter'  class-methods-use-this
     // renderFooter() {
     //     return null;
     // }

--- a/src/components/include/DefaultImportModalDialog.jsx
+++ b/src/components/include/DefaultImportModalDialog.jsx
@@ -81,6 +81,7 @@ class DefaultImportModalDialog extends ModalDialog {
         const newMaterial = new Material(newMaterialConfig);
         newMaterial.cleanOnCopy();
 
+        Made.tools.material.getBasisConfigTranslatedToCenter(newMaterial);
         this.props.onSubmit([newMaterial]);
     }
 

--- a/src/components/include/DefaultImportModalDialog.jsx
+++ b/src/components/include/DefaultImportModalDialog.jsx
@@ -1,0 +1,190 @@
+import { Made } from "@exabyte-io/made.js";
+import { PropTypes } from "prop-types";
+import React from "react";
+import { ModalBody, ModalHeader } from "react-bootstrap";
+import NPMsAlert from "react-s-alert";
+import _ from "underscore";
+
+import { Material } from "../../material";
+import BasisText from "../source_editor/BasisText";
+import { ModalDialog } from "./ModalDialog";
+
+export const defaultXYZMaterialConfig = {
+    name: "Custom XYZ",
+    basis: {
+        elements: [
+            {
+                id: 1,
+                value: "H",
+            },
+        ],
+        coordinates: [
+            {
+                id: 1,
+                value: [0.0, 0.0, 0.0],
+            },
+        ],
+        units: Made.ATOMIC_COORD_UNITS.cartesian,
+    },
+    lattice: {
+        type: Made.LATTICE_TYPE_CONFIGS[1].code, // FCC, to be exported by made.js
+        a: 500.0, // NB will be rewritten with mockLatticeConstant
+        b: 500.0,
+        c: 500.0,
+        alpha: 90,
+        beta: 90,
+        gamma: 90,
+        units: {
+            length: Made.units.angstrom,
+            angle: Made.units.degree,
+        },
+    },
+};
+
+const mockLatticeConstantMultiplicator = 2.0;
+
+class DefaultImportModalDialog extends ModalDialog {
+    constructor(props) {
+        super(props);
+        this.state = {
+            xyz: "Paste your XYZ",
+        };
+        this.handleSubmit = this.handleSubmit.bind(this);
+        this.handleChange = this.handleChange.bind(this);
+        this.handleFileRead = this.handleFileRead.bind(this);
+
+        this.reader = new FileReader();
+        this.reader.onloadend = this.handleFileRead;
+    }
+
+    handleFileRead(evt) {
+        this.setState({ xyz: evt.target.result });
+    }
+
+    handleSubmit() {
+        if (!this.BasisTextComponent.state.isContentValidated) return;
+
+        const basisConfig = Made.parsers.xyz.toBasisConfig(
+            this.state.xyz,
+            Made.ATOMIC_COORD_UNITS.cartesian,
+        );
+
+        // determine the max distance to use for cell for user's XYZ
+        const x = [];
+        const y = [];
+        const z = [];
+        basisConfig.coordinates.forEach((item) => {
+            x.push(item.value[0]);
+            y.push(item.value[1]);
+            z.push(item.value[2]);
+        });
+
+        const diffX = _.max(x) - _.min(x);
+        const diffY = _.max(y) - _.min(y);
+        const diffZ = _.max(z) - _.min(z);
+        const mockLatticeConstant = _.max([diffX, diffY, diffZ]) * mockLatticeConstantMultiplicator;
+
+        const material = new Made.Material(defaultXYZMaterialConfig);
+
+        const latticeConfig = {
+            ...material.lattice,
+            ...{
+                a: mockLatticeConstant,
+                b: mockLatticeConstant,
+                c: mockLatticeConstant,
+            },
+        };
+        const lattice = new Made.Lattice(latticeConfig);
+
+        const basis = new Made.Basis({
+            ...basisConfig,
+            cell: lattice.vectorArrays,
+        });
+
+        const newMaterialConfig = {
+            ...material.toJSON(),
+            ...{
+                basis: basis.toJSON(),
+                lattice: lattice.toJSON(),
+                name: `${material.name} - ${basis.formula}`,
+            },
+        };
+        const newMaterial = new Material(newMaterialConfig);
+        newMaterial.cleanOnCopy();
+
+        this.props.onSubmit([newMaterial]);
+    }
+
+    handleChange(content) {
+        this.setState({ xyz: content });
+    }
+
+    handleFileChange(files) {
+        if (!files[0] || !files[0].size)
+            return NPMsAlert.warning("Error: file cannot be read (unaccessible?)");
+        this.reader.currentFilename = files[0].name;
+        this.reader.readAsText(files[0]);
+    }
+
+    renderHeader() {
+        return (
+            <ModalHeader className="bgm-dark" closeButton>
+                <h4 className="modal-title">
+                    {this.props.title}
+                    <a
+                        className="m-l-10 combinatorial-info"
+                        href="https://docs.exabyte.io/materials-designer/header-menu/advanced/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        <i className="zmdi zmdi-info" />
+                    </a>
+                </h4>
+            </ModalHeader>
+        );
+    }
+
+    renderBody() {
+        return (
+            <ModalBody className="bgm-dark">
+                <BasisText
+                    ref={(el) => {
+                        this.BasisTextComponent = el;
+                    }}
+                    className="default-import-modal-basis-text"
+                    content={this.state.xyz}
+                    onChange={this.handleChange}
+                />
+                <input
+                    type="file"
+                    id="fileapi"
+                    onChange={(event) => this.handleFileChange(event.target.files)}
+                />
+
+                <div className="row m-t-10">
+                    <div className="col-md-12">
+                        <button
+                            id="default-import-modal-submit"
+                            className="btn btn-custom btn-block"
+                            type="button"
+                            onClick={this.handleSubmit}
+                        >
+                            Submit your XYZ
+                        </button>
+                    </div>
+                </div>
+            </ModalBody>
+        );
+    }
+
+    // renderFooter() {
+    //     return null;
+    // }
+}
+
+DefaultImportModalDialog.PropTypes = {
+    onSubmit: PropTypes.func,
+    material: PropTypes.object,
+};
+
+export default DefaultImportModalDialog;


### PR DESCRIPTION
## Summary

This PR adds a feature to import local XYZ files. Partially based on the implementation in #26 with some subsequent cleanups and reusing objects from existing libraries.

Closes #26.

## Example

An example input was taken from https://www.gloriabazargan.com/blog/visualizing-molecules:

![image](https://user-images.githubusercontent.com/13209176/222015044-0bf5c47b-483e-42eb-b722-5a984518a7d1.png)

One needs to remove the first two lines to make it work with the current version of the parser:
```
17       <-- remove this line
Pentane  <-- remove this line
C      -0.06119     -0.14438     -0.09006
H      -0.06046     -0.76500      0.81047
H       0.04110     -0.82551     -0.94388
C       1.13633      0.80196     -0.06785
H       1.04730      1.50136      0.77446
H       1.16482      1.40068     -0.98213
C       2.43464      0.02076      0.06562
H       2.42913     -0.60381      0.96237
H       3.28623      0.69990      0.13111
H       2.58851     -0.63256     -0.80327
C      -1.39343      0.59934     -0.18301
H      -1.35021      1.39778     -0.92849
H      -1.60573      1.07576      0.78352
C      -2.52277     -0.35635     -0.53888
H      -3.48791      0.04616     -0.21351
H      -2.38991     -1.33607     -0.06587
H      -2.57051     -0.50852     -1.61872
```

## Screenshot
![image](https://user-images.githubusercontent.com/13209176/222015228-8f7ef933-e424-4e15-a3fe-af9750f42a09.png)
