### PR TITLE
fix: bump stale @exabyte-io/wave.js pin to pick up cove rename

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
                 "@babel/runtime-corejs2": "7.16.7",
                 "@emotion/react": "^11.13.0",
                 "@emotion/styled": "^11.13.0",
-                "@exabyte-io/wave.js": "2026.6.30-0",
+                "@exabyte-io/wave.js": "2026.7.18-0",
                 "@mat3ra/utils": "2026.5.28-4",
                 "@mui/icons-material": "^5.11.0",
                 "@mui/lab": "^5.0.0-alpha.120",
@@ -3828,9 +3828,9 @@
             "license": "MIT"
         },
         "node_modules/@exabyte-io/wave.js": {
-            "version": "2026.6.30-0",
-            "resolved": "https://registry.npmjs.org/@exabyte-io/wave.js/-/wave.js-2026.6.30-0.tgz",
-            "integrity": "sha512-dXf5c3E8Mb/fnkxPffNedAyuzImWltTwYxLAV+4tT7BJfGGTdXdm39cbqRiswLsetz6adKrTQpxh/7KfwDvf3Q==",
+            "version": "2026.7.18-0",
+            "resolved": "https://registry.npmjs.org/@exabyte-io/wave.js/-/wave.js-2026.7.18-0.tgz",
+            "integrity": "sha512-ql4VBHCl9bxj3ZPfBnL2cx3ddZaw3kVfD4MX513ErZbY4H+amhFR4VSzj5e0b/pFDxroLPjOunZ1h2JQwe+ppw==",
             "license": "Apache-2.0",
             "dependencies": {
                 "@emotion/react": "^11.10.5",
@@ -3858,8 +3858,8 @@
                 "node": ">=20.0.0"
             },
             "peerDependencies": {
-                "@exabyte-io/cove.js": "*",
                 "@mat3ra/code": "*",
+                "@mat3ra/cove": "*",
                 "@mat3ra/esse": "*",
                 "@mat3ra/made": "*",
                 "@mat3ra/utils": "*",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "@babel/runtime-corejs2": "7.16.7",
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
-        "@exabyte-io/wave.js": "2026.6.30-0",
+        "@exabyte-io/wave.js": "2026.7.18-0",
         "@mat3ra/utils": "2026.5.28-4",
         "@mui/icons-material": "^5.11.0",
         "@mui/material": "^5.11.9",


### PR DESCRIPTION
Fixes the CI failure from `#276` (merged): materials-designer's own direct cove dependency was renamed to `@mat3ra/cove`, so npm no longer installs `@exabyte-io/cove.js` as a top-level/hoisted dependency. The pinned `@exabyte-io/wave.js` (`2026.6.30-0`) predates wave.js's own cove migration and its compiled dist still imports `@exabyte-io/cove.js/dist/*` paths directly, which then fail to resolve — breaking the esbuild bundle in CI.

Bumps to `2026.7.18-0`, which imports `@mat3ra/cove` instead.

Verified locally: `npm run build` (vite build) succeeds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)