### PR TITLE
chore: consume wave.js from @mat3ra scope

### DIFF
--- a/dist/MaterialsDesignerContainer.d.ts
+++ b/dist/MaterialsDesignerContainer.d.ts
@@ -1,4 +1,4 @@
-import type { ViewSettingsFromUrl } from "@exabyte-io/wave.js/dist/utils/viewSettingsUrl";
+import type { ViewSettingsFromUrl } from "@mat3ra/wave.js/dist/utils/viewSettingsUrl";
 import { MDMaterial } from "./MDMaterial";
 import { type MDState } from "./reducers/Material";
 declare global {

--- a/dist/MaterialsDesignerContainer.js
+++ b/dist/MaterialsDesignerContainer.js
@@ -1,4 +1,5 @@
 import { jsx as _jsx } from "react/jsx-runtime";
+/* eslint-disable react/jsx-props-no-spreading */
 import { AlertProvider } from "@mat3ra/cove/dist/theme/provider";
 import React, { useCallback, useEffect, useState } from "react";
 import MaterialsDesignerComponent from "./MaterialsDesigner";

--- a/dist/components/3d_editor/ThreeDEditorFullscreen.d.ts
+++ b/dist/components/3d_editor/ThreeDEditorFullscreen.d.ts
@@ -9,5 +9,5 @@ export namespace ThreeDEditorFullscreen {
         const initialViewSettings: PropTypes.Requireable<object>;
     }
 }
-import { ThreeDEditor } from "@exabyte-io/wave.js";
+import { ThreeDEditor } from "@mat3ra/wave.js";
 import PropTypes from "prop-types";

--- a/dist/components/3d_editor/ThreeDEditorFullscreen.js
+++ b/dist/components/3d_editor/ThreeDEditorFullscreen.js
@@ -1,4 +1,4 @@
-import { ThreeDEditor } from "@exabyte-io/wave.js";
+import { ThreeDEditor } from "@mat3ra/wave.js";
 import PropTypes from "prop-types";
 // TODO: clean up when touching this next time
 export class ThreeDEditorFullscreen extends ThreeDEditor {

--- a/dist/components/3d_editor/advanced_geometry/BoundaryConditionsDialog.js
+++ b/dist/components/3d_editor/advanced_geometry/BoundaryConditionsDialog.js
@@ -1,6 +1,6 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 import Dialog from "@mat3ra/cove/dist/mui/components/dialog/Dialog";
-import { BOUNDARY_CONDITIONS } from "@exabyte-io/wave.js/dist/enums";
+import { BOUNDARY_CONDITIONS } from "@mat3ra/wave.js/dist/enums";
 import Grid from "@mui/material/Grid";
 import MenuItem from "@mui/material/MenuItem";
 import TextField from "@mui/material/TextField";

--- a/dist/components/header_menu/HeaderMenuToolbar.js
+++ b/dist/components/header_menu/HeaderMenuToolbar.js
@@ -1,7 +1,7 @@
 import { jsx as _jsx, jsxs as _jsxs } from "react/jsx-runtime";
 /* eslint-disable react/sort-comp */
 import IconByName from "@mat3ra/cove/dist/mui/components/icon/IconByName";
-import { ThreejsEditorModal } from "@exabyte-io/wave.js";
+import { ThreejsEditorModal } from "@mat3ra/wave.js";
 import AddCircleIcon from "@mui/icons-material/AddCircle";
 import AssignmentIcon from "@mui/icons-material/Assignment";
 // TODO: rename other menu icons similarly

--- a/dist/exports.d.ts
+++ b/dist/exports.d.ts
@@ -4,4 +4,4 @@ export { MDMaterial } from "./MDMaterial";
 export { ActionDialog } from "./components/include/ActionDialog";
 export { MaterialsDesignerContainer } from "./MaterialsDesignerContainer";
 export { ThreeDEditorFullscreen } from "./components/3d_editor/ThreeDEditorFullscreen";
-export { parseViewSettingsFromUrlParams, serializeViewSettingsToUrlParams } from "@exabyte-io/wave.js";
+export { parseViewSettingsFromUrlParams, serializeViewSettingsToUrlParams } from "@mat3ra/wave.js";

--- a/dist/exports.js
+++ b/dist/exports.js
@@ -4,4 +4,4 @@ export { MDMaterial } from "./MDMaterial";
 export { ActionDialog } from "./components/include/ActionDialog";
 export { MaterialsDesignerContainer } from "./MaterialsDesignerContainer";
 export { ThreeDEditorFullscreen } from "./components/3d_editor/ThreeDEditorFullscreen";
-export { parseViewSettingsFromUrlParams, serializeViewSettingsToUrlParams, } from "@exabyte-io/wave.js";
+export { parseViewSettingsFromUrlParams, serializeViewSettingsToUrlParams } from "@mat3ra/wave.js";

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,6 +1,6 @@
 import { jsx as _jsx } from "react/jsx-runtime";
 // Load styling, bootstrap needs to be loaded first
-import "@exabyte-io/wave.js/dist/stylesheets/main.css";
+import "@mat3ra/wave.js/dist/stylesheets/main.css";
 import "./stylesheets/main.css";
 // eslint-disable-next-line import/no-unresolved, import/no-extraneous-dependencies
 import React from "react";

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,8 +15,8 @@
                 "@babel/runtime-corejs2": "7.16.7",
                 "@emotion/react": "^11.13.0",
                 "@emotion/styled": "^11.13.0",
-                "@exabyte-io/wave.js": "2026.7.18-0",
                 "@mat3ra/utils": "2026.5.28-4",
+                "@mat3ra/wave.js": "2026.7.18-1",
                 "@mui/icons-material": "^5.11.0",
                 "@mui/lab": "^5.0.0-alpha.120",
                 "@mui/material": "^5.11.9",
@@ -3827,59 +3827,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/@exabyte-io/wave.js": {
-            "version": "2026.7.18-0",
-            "resolved": "https://registry.npmjs.org/@exabyte-io/wave.js/-/wave.js-2026.7.18-0.tgz",
-            "integrity": "sha512-ql4VBHCl9bxj3ZPfBnL2cx3ddZaw3kVfD4MX513ErZbY4H+amhFR4VSzj5e0b/pFDxroLPjOunZ1h2JQwe+ppw==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "@emotion/react": "^11.10.5",
-                "@emotion/styled": "^11.10.5",
-                "@mat3ra/periodic-table": "2025.1.18-1",
-                "@mui/icons-material": "^5.11.0",
-                "@mui/lab": "^5.0.0-alpha.120",
-                "@mui/material": "^5.11.9",
-                "@mui/styles": "^5.11.7",
-                "classnames": "^2.3.1",
-                "gifshot": "^0.4.5",
-                "jquery": "3.6.0",
-                "mixwith": "^0.1.1",
-                "moment": "^2.29.4",
-                "pixelmatch": "^5.3.0",
-                "prop-types": "^15.8.0",
-                "sprintf-js": "^1.1.2",
-                "static-kdtree": "^1.0.2",
-                "three": "npm:@exabyte-io/three@2023.8.23-0",
-                "typescript": "^5.7.3",
-                "underscore": "^1.8.3",
-                "underscore.string": "^3.3.4"
-            },
-            "engines": {
-                "node": ">=20.0.0"
-            },
-            "peerDependencies": {
-                "@mat3ra/code": "*",
-                "@mat3ra/cove": "*",
-                "@mat3ra/esse": "*",
-                "@mat3ra/made": "*",
-                "@mat3ra/utils": "*",
-                "react": "^17.0.0",
-                "react-dom": "^17.0.0"
-            }
-        },
-        "node_modules/@exabyte-io/wave.js/node_modules/typescript": {
-            "version": "5.9.3",
-            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-            "license": "Apache-2.0",
-            "bin": {
-                "tsc": "bin/tsc",
-                "tsserver": "bin/tsserver"
-            },
-            "engines": {
-                "node": ">=14.17"
-            }
-        },
         "node_modules/@floating-ui/core": {
             "version": "1.7.5",
             "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
@@ -5847,6 +5794,59 @@
             "license": "MIT",
             "engines": {
                 "node": ">= 18"
+            }
+        },
+        "node_modules/@mat3ra/wave.js": {
+            "version": "2026.7.18-1",
+            "resolved": "https://registry.npmjs.org/@mat3ra/wave.js/-/wave.js-2026.7.18-1.tgz",
+            "integrity": "sha512-R+0HrLmAnYGAteprrJ6IqO2g6VrpNcy5mAuCQ8PKGOoWfxxlwwM2VS0VtumOHmfhmcV+waWK8SHk8xL3RQYJHw==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@emotion/react": "^11.10.5",
+                "@emotion/styled": "^11.10.5",
+                "@mat3ra/periodic-table": "2025.1.18-1",
+                "@mui/icons-material": "^5.11.0",
+                "@mui/lab": "^5.0.0-alpha.120",
+                "@mui/material": "^5.11.9",
+                "@mui/styles": "^5.11.7",
+                "classnames": "^2.3.1",
+                "gifshot": "^0.4.5",
+                "jquery": "3.6.0",
+                "mixwith": "^0.1.1",
+                "moment": "^2.29.4",
+                "pixelmatch": "^5.3.0",
+                "prop-types": "^15.8.0",
+                "sprintf-js": "^1.1.2",
+                "static-kdtree": "^1.0.2",
+                "three": "npm:@exabyte-io/three@2023.8.23-0",
+                "typescript": "^5.7.3",
+                "underscore": "^1.8.3",
+                "underscore.string": "^3.3.4"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            },
+            "peerDependencies": {
+                "@mat3ra/code": "*",
+                "@mat3ra/cove": "*",
+                "@mat3ra/esse": "*",
+                "@mat3ra/made": "*",
+                "@mat3ra/utils": "*",
+                "react": "^17.0.0",
+                "react-dom": "^17.0.0"
+            }
+        },
+        "node_modules/@mat3ra/wave.js/node_modules/typescript": {
+            "version": "5.9.3",
+            "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+            "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+            "license": "Apache-2.0",
+            "bin": {
+                "tsc": "bin/tsc",
+                "tsserver": "bin/tsserver"
+            },
+            "engines": {
+                "node": ">=14.17"
             }
         },
         "node_modules/@mui/core-downloads-tracker": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
         "test": "echo 'Tests are in the tests subfolder. Use Node 20 (`nvm use 20`) and run `npm i` && `npm test` there'",
         "lint": "eslint src && prettier --write src",
         "lint:fix": "eslint src --fix && prettier --write src",
-        "prestart": "npm-link-shared ./node_modules/@mat3ra/cove/node_modules . react; npm-link-shared ./node_modules/@exabyte-io/wave.js/node_modules . react",
+        "prestart": "npm-link-shared ./node_modules/@mat3ra/cove/node_modules . react; npm-link-shared ./node_modules/@mat3ra/wave.js/node_modules . react",
         "prettier": "prettier --check src tests"
     },
     "repository": {
@@ -32,7 +32,7 @@
         "@babel/runtime-corejs2": "7.16.7",
         "@emotion/react": "^11.13.0",
         "@emotion/styled": "^11.13.0",
-        "@exabyte-io/wave.js": "2026.7.18-0",
+        "@mat3ra/wave.js": "2026.7.18-1",
         "@mat3ra/utils": "2026.5.28-4",
         "@mui/icons-material": "^5.11.0",
         "@mui/material": "^5.11.9",

--- a/src/MaterialsDesignerContainer.tsx
+++ b/src/MaterialsDesignerContainer.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react/jsx-props-no-spreading */
-import type { ViewSettingsFromUrl } from "@exabyte-io/wave.js/dist/utils/viewSettingsUrl";
 import { AlertProvider } from "@mat3ra/cove/dist/theme/provider";
 import type { Matrix3X3Schema } from "@mat3ra/esse/dist/js/types";
+import type { ViewSettingsFromUrl } from "@mat3ra/wave.js/dist/utils/viewSettingsUrl";
 import React, { useCallback, useEffect, useState } from "react";
 
 import MaterialsDesignerComponent from "./MaterialsDesigner";

--- a/src/components/3d_editor/ThreeDEditorFullscreen.jsx
+++ b/src/components/3d_editor/ThreeDEditorFullscreen.jsx
@@ -1,4 +1,4 @@
-import { ThreeDEditor } from "@exabyte-io/wave.js";
+import { ThreeDEditor } from "@mat3ra/wave.js";
 import PropTypes from "prop-types";
 
 // TODO: clean up when touching this next time

--- a/src/components/3d_editor/advanced_geometry/BoundaryConditionsDialog.jsx
+++ b/src/components/3d_editor/advanced_geometry/BoundaryConditionsDialog.jsx
@@ -1,5 +1,5 @@
 import Dialog from "@mat3ra/cove/dist/mui/components/dialog/Dialog";
-import { BOUNDARY_CONDITIONS } from "@exabyte-io/wave.js/dist/enums";
+import { BOUNDARY_CONDITIONS } from "@mat3ra/wave.js/dist/enums";
 import Grid from "@mui/material/Grid";
 import MenuItem from "@mui/material/MenuItem";
 import TextField from "@mui/material/TextField";

--- a/src/components/header_menu/HeaderMenuToolbar.jsx
+++ b/src/components/header_menu/HeaderMenuToolbar.jsx
@@ -1,6 +1,6 @@
 /* eslint-disable react/sort-comp */
 import IconByName from "@mat3ra/cove/dist/mui/components/icon/IconByName";
-import { ThreejsEditorModal } from "@exabyte-io/wave.js";
+import { ThreejsEditorModal } from "@mat3ra/wave.js";
 import AddCircleIcon from "@mui/icons-material/AddCircle";
 import AssignmentIcon from "@mui/icons-material/Assignment";
 // TODO: rename other menu icons similarly

--- a/src/exports.js
+++ b/src/exports.js
@@ -4,7 +4,4 @@ export { MDMaterial } from "./MDMaterial";
 export { ActionDialog } from "./components/include/ActionDialog";
 export { MaterialsDesignerContainer } from "./MaterialsDesignerContainer";
 export { ThreeDEditorFullscreen } from "./components/3d_editor/ThreeDEditorFullscreen";
-export {
-    parseViewSettingsFromUrlParams,
-    serializeViewSettingsToUrlParams,
-} from "@exabyte-io/wave.js";
+export { parseViewSettingsFromUrlParams, serializeViewSettingsToUrlParams } from "@mat3ra/wave.js";

--- a/src/index.jsx
+++ b/src/index.jsx
@@ -1,5 +1,5 @@
 // Load styling, bootstrap needs to be loaded first
-import "@exabyte-io/wave.js/dist/stylesheets/main.css";
+import "@mat3ra/wave.js/dist/stylesheets/main.css";
 import "./stylesheets/main.css";
 
 // eslint-disable-next-line import/no-unresolved, import/no-extraneous-dependencies


### PR DESCRIPTION
\`@exabyte-io/wave.js\` was renamed to \`@mat3ra/wave.js\` (mat3ra/wave.js#206). Switches the dependency and every import path (src + committed dist), bumps to \`2026.7.18-1\`.

Verified locally: \`npm run build\` (vite build) succeeds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)