### PR TITLE
fix: JupyterLite sidebar double-click matched by substring, not exact name

### DIFF
--- a/tests/cypress/support/widgets/JupyterLiteSession.ts
+++ b/tests/cypress/support/widgets/JupyterLiteSession.ts
@@ -69,9 +69,15 @@ export default class JupyterLiteSession extends Widget {
 
     doubleclickEntryInSidebar(sidebarEntry: string) {
         this.iframeAnchor.waitForExist(SELECTORS.sidebar.listing);
-        this.iframeAnchor.doubleClickOnText(sidebarEntry, SELECTORS.sidebar.listing, {
-            force: true,
-        });
+        // JupyterLab sets each item's `title` attribute to "Name: <exact name>\n...".
+        // Matching on that (rather than cy.contains(text), a substring match over the
+        // rendered text) means a shorter name never accidentally matches a longer one
+        // that merely starts with it (e.g. "formation_energy.ipynb" vs
+        // "defect_formation_energy.ipynb" in the same folder).
+        const escaped = sidebarEntry.replace(/\\/g, "\\\\").replace(/"/g, '\\"');
+        this.iframeAnchor
+            .get(`${SELECTORS.sidebar.listing}[title^="Name: ${escaped}\n"]`)
+            .dblclick({ force: true });
     }
 
     assertPathInSidebar(path: string) {


### PR DESCRIPTION
## Summary
- `doubleclickEntryInSidebar` matched entries with `cy.contains(text)`, a substring match over the rendered listing text. When one item's name was a prefix of another's in the same folder (e.g. `formation_energy.ipynb` vs `defect_formation_energy.ipynb`), the shorter name could match and silently open the wrong file, depending on DOM/alphabetical order.
- Now matches on the item's own `title` attribute, which JupyterLab sets to `"Name: <exact name>\n..."`. Anchoring on `^="Name: <name>\n"` matches only an item whose name is exactly the query — correct for any file/folder name in any listing, not a one-off workaround for a single colliding pair.

## Test plan
- [x] Verified against a live JupyterLite session in web-app (local): all previously-colliding notebook pairs (`formation_energy`/`defect_formation_energy`, `surface_energy`, `interfacial_energy`) open correctly.
- [x] Verified via a local tarball install (`npm pack` + `npm install <tarball>`) in `web-app/src/tests-cypress`, running all 4 `api-examples` feature files plus a broader sample of existing sidebar-navigation usages — zero regressions, no separate "exact match" step needed anywhere.
- [x] `package-lock.json` reverted to registry state before push (unrelated lockfile churn from local env setup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)